### PR TITLE
Call `end` callback even if the event was already triggered

### DIFF
--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -33,6 +33,15 @@ wary.it 'should be fulfilled if operations is undefined', {}, ->
 	promise = utils.waitStreamToClose(configuration)
 	m.chai.expect(promise).to.eventually.be.undefined
 
+wary.it 'should be fulfilled even if it finished long ago', {}, ->
+	f = ->
+		configuration = operations.execute(RASPBERRY_PI)
+		Promise.delay(1000).return(configuration)
+
+	f().then (configuration) ->
+		promise = utils.waitStreamToClose(configuration)
+		m.chai.expect(promise).to.eventually.be.undefined
+
 wary.it 'should be rejected if the command does not exist',
 	raspberrypi: RASPBERRY_PI
 , (images) ->


### PR DESCRIPTION
If the `end` event is emitted after the corresponding listener was
registered, the event callback is not going to be called ever.

As a workaround, we mark `emitter.ended = true` when the `end` event is
first triggered, and then stub `emitter.on()` to check for this flag and
call the callback event long after.