### PR TITLE
Throw not found command instead of rejecting a promise

### DIFF
--- a/build/action.js
+++ b/build/action.js
@@ -89,7 +89,7 @@ exports.run = function(image, operation, options) {
   var action;
   action = commands[operation.command];
   if (action == null) {
-    return Promise.reject(new Error("Unknown command: " + operation.command));
+    throw new Error("Unknown command: " + operation.command);
   }
   return _.partial(action, image, operation, options);
 };

--- a/lib/action.coffee
+++ b/lib/action.coffee
@@ -79,6 +79,6 @@ exports.run = (image, operation, options) ->
 	action = commands[operation.command]
 
 	if not action?
-		return Promise.reject(new Error("Unknown command: #{operation.command}"))
+		throw new Error("Unknown command: #{operation.command}")
 
 	return _.partial(action, image, operation, options)

--- a/tests/action.spec.coffee
+++ b/tests/action.spec.coffee
@@ -31,10 +31,10 @@ describe 'Command:', ->
 	describe '.run()', ->
 
 		it 'should be rejected if the command type is invalid', ->
-			promise = action.run 'foo/bar',
+			m.chai.expect ->
+				action.run 'foo/bar',
 				command: 'foobar'
-
-			m.chai.expect(promise).to.be.rejectedWith('Unknown command: foobar')
+			.to.throw('Unknown command: foobar')
 
 		describe 'given the command type exists', ->
 

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -46,12 +46,11 @@ wary.it 'should be fulfilled even if it finished long ago', {}, ->
 wary.it 'should be rejected if the command does not exist',
 	raspberrypi: RASPBERRY_PI
 , (images) ->
-	configuration = operations.execute images.raspberrypi, [
-		command: 'foobar'
-	]
-
-	promise = utils.waitStreamToClose(configuration)
-	m.chai.expect(promise).to.be.rejectedWith('Unknown command: foobar')
+	m.chai.expect ->
+		operations.execute images.raspberrypi, [
+			command: 'foobar'
+		]
+	.to.throw('Unknown command: foobar')
 
 wary.it 'should be able to copy a single file between raspberry pi partitions',
 	raspberrypi: RASPBERRY_PI


### PR DESCRIPTION
The code that checks this doesn't run in a promise chain.
