### PR TITLE
Fix missed first state event after a slight delay

### DIFF
--- a/lib/operations.coffee
+++ b/lib/operations.coffee
@@ -119,27 +119,28 @@ exports.execute = (image, operations, options) ->
 				return callback()
 			emitterOn.apply(emitter, arguments)
 
-		Promise.each promises, (promise, index) ->
-			state =
-				operation: operations[index]
-				percentage: action.getOperationProgress(index, operations)
+		Promise.delay(1).then ->
+			Promise.each promises, (promise, index) ->
+				state =
+					operation: operations[index]
+					percentage: action.getOperationProgress(index, operations)
 
-			emitter.emit('state', state)
+				emitter.emit('state', state)
 
-			promise().then (actionEvent) ->
+				promise().then (actionEvent) ->
 
-				# Pipe stdout/stderr events
-				actionEvent.stdout?.on 'data', (data) ->
-					emitter.emit('stdout', data)
+					# Pipe stdout/stderr events
+					actionEvent.stdout?.on 'data', (data) ->
+						emitter.emit('stdout', data)
 
-				actionEvent.stderr?.on 'data', (data) ->
-					emitter.emit('stderr', data)
+					actionEvent.stderr?.on 'data', (data) ->
+						emitter.emit('stderr', data)
 
-				# Emit burn command progress state as `burn`
-				actionEvent.on 'progress', (state) ->
-					emitter.emit('burn', state)
+					# Emit burn command progress state as `burn`
+					actionEvent.on 'progress', (state) ->
+						emitter.emit('burn', state)
 
-				return utils.waitStreamToClose(actionEvent)
+					return utils.waitStreamToClose(actionEvent)
 	.then ->
 		emitter.emit('end')
 

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -305,6 +305,40 @@ wary.it 'should emit state events for operations',
 				replace: 'lpm_enable=1'
 			percentage: 100
 
+wary.it 'should read state events for operations after a slight delay',
+	raspberrypi: RASPBERRY_PI
+, (images) ->
+
+	configure = ->
+		Promise.try ->
+			return operations.execute images.raspberrypi, [
+				command: 'replace'
+				file:
+					partition:
+						primary: 1
+					path: '/cmdline.txt'
+				find: 'lpm_enable=0'
+				replace: 'lpm_enable=1'
+			]
+
+	configure().then (configuration) ->
+		stateSpy = m.sinon.spy()
+		configuration.on('state', stateSpy)
+
+		utils.waitStreamToClose(configuration).then ->
+			m.chai.expect(stateSpy).to.have.been.calledOnce
+			m.chai.expect(stateSpy.firstCall.args[0]).to.deep.equal
+				operation:
+					command: 'replace'
+					file:
+						image: images.raspberrypi
+						partition:
+							primary: 1
+						path: '/cmdline.txt'
+					find: 'lpm_enable=0'
+					replace: 'lpm_enable=1'
+				percentage: 100
+
 wary.it 'should run a script with arguments that exits successfully', {}, ->
 	configuration = operations.execute EDISON_ZIP, [
 		command: 'run-script'


### PR DESCRIPTION
From Resin Device Init, we have a function that returns a promise to an
operation object, therefore there is a slight delay between initiation
the operations and the client code subscribing to its `state` event,
causing in some cases to lose the first `state` event.

The solution is adding a slight delay between returning the operations
emitter object and starting to execute the operations.
