### PR TITLE
Add `length` property to readable stream in burn command

### DIFF
--- a/build/commands.js
+++ b/build/commands.js
@@ -26,9 +26,9 @@ var Promise, child_process, fs, imageWrite, imagefs, path;
 
 Promise = require('bluebird');
 
-child_process = require('child_process');
+fs = Promise.promisifyAll(require('fs'));
 
-fs = require('fs');
+child_process = require('child_process');
 
 path = require('path');
 
@@ -68,11 +68,16 @@ module.exports = {
       operation.image = image;
     }
     return Promise["try"](function() {
-      var imageReadStream;
       if ((options != null ? options.drive : void 0) == null) {
         throw new Error('Missing drive option');
       }
+      return operation.image;
+    }).then(fs.statAsync).get('size').then(function(size) {
+      var imageReadStream;
       imageReadStream = fs.createReadStream(operation.image);
+      if (imageReadStream.length == null) {
+        imageReadStream.length = size;
+      }
       return imageWrite.write(options.drive, imageReadStream);
     });
   }

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -23,8 +23,8 @@ THE SOFTWARE.
 ###
 
 Promise = require('bluebird')
+fs = Promise.promisifyAll(require('fs'))
 child_process = require('child_process')
-fs = require('fs')
 path = require('path')
 imagefs = require('resin-image-fs')
 imageWrite = require('resin-image-write')
@@ -63,5 +63,13 @@ module.exports =
 			if not options?.drive?
 				throw new Error('Missing drive option')
 
+			return operation.image
+		.then(fs.statAsync).get('size')
+		.then (size) ->
 			imageReadStream = fs.createReadStream(operation.image)
+
+			# This is read by Resin Image Write to
+			# emit correct `progress` events.
+			imageReadStream.length ?= size
+
 			return imageWrite.write(options.drive, imageReadStream)

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -413,7 +413,18 @@ wary.it 'should be able to burn an image',
 	],
 		drive: images.random
 
+	progressSpy = m.sinon.spy()
+	configuration.on('burn', progressSpy)
+
 	utils.waitStreamToClose(configuration).then ->
+
+		fse.statAsync(images.raspberrypi).get('size').then (size) ->
+			m.chai.expect(progressSpy).to.have.been.called
+			state = progressSpy.firstCall.args[0]
+			m.chai.expect(state.length).to.not.equal(0)
+			m.chai.expect(state.length).to.equal(size)
+
+	.then ->
 		Promise.props
 			raspberrypi: fse.readFileAsync(images.raspberrypi)
 			random: fse.readFileAsync(images.random)


### PR DESCRIPTION
Resin Image Write relies on a `length` property being present in the
readable stream that's passed to it to correctly report progress
information.

Currently, the `length` property was missing in Resin Device Operations,
losing most of progress information (eta, etc).

The fix is to use `fs.stat` to get the size of the image, and append it
as `length` is that property doesn't already exist.