### PR TITLE
Upgrade Resin Image Write to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bluebird": "^2.9.34",
     "lodash": "^3.10.0",
     "resin-image-fs": "^2.1.0",
-    "resin-image-write": "^1.0.0",
+    "resin-image-write": "^2.0.0",
     "underscore.string": "^3.1.1"
   }
 }


### PR DESCRIPTION
This version contains fixes for correctly getting stream size
information.