### PR TITLE
Prevent duplicates from missing options

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -149,5 +149,5 @@ exports.getMissingOptions = function(operations, options) {
     options = {};
   }
   usedOptions = _.flatten(_.map(_.pluck(operations, 'when'), _.keys));
-  return _.difference(usedOptions, _.keys(options));
+  return _.uniq(_.difference(usedOptions, _.keys(options)));
 };

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -125,4 +125,4 @@ exports.filterWhenMatches = (operations, options = {}) ->
 ###
 exports.getMissingOptions = (operations, options = {}) ->
 	usedOptions = _.flatten(_.map(_.pluck(operations, 'when'), _.keys))
-	return _.difference(usedOptions, _.keys(options))
+	return _.uniq(_.difference(usedOptions, _.keys(options)))

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -248,3 +248,24 @@ describe 'Utils:', ->
 					bar: 2
 					baz: 3
 				m.chai.expect(result).to.deep.equal([])
+
+		describe 'given multiple command operations asking for the same option', ->
+
+			beforeEach ->
+				@operations = [
+					command: 'foo'
+					when:
+						os: 'osx'
+				,
+					command: 'foo'
+					when:
+						os: 'linux'
+				,
+					command: 'foo'
+					when:
+						os: 'win32'
+				]
+
+			it 'should return the missing option once', ->
+				result = utils.getMissingOptions(@operations, null)
+				m.chai.expect(result).to.deep.equal([ 'os' ])


### PR DESCRIPTION
Consider an operations array containing commands that match a single
option with different values. For example:

	operations: [
		command: 'run-script'
		script: 'flashall.bat'
		when:
			os: 'win32'
	,
		command: 'run-script'
		script: 'flashall.sh'
		when:
			os: 'osx'
	,
		command: 'run-script'
		script: 'flashall.sh'
		when:
			os: 'linux'
	]

In this case, these three commands require an `os` option, and match
different values of such option.

We calculate missing options by getting all the values from `when`
properties. Therefore, in the above example, the missing options will
be:

	[ 'os', 'os', 'os' ]

This leads to issues when displaying the missing options, since the user
will see:

	Missing options: os, os and os

The solution is to simply remove the duplicates with `_.uniq`.