### PR TITLE
Ensure execution permissions from scripts

### DIFF
--- a/build/commands.js
+++ b/build/commands.js
@@ -59,7 +59,7 @@ module.exports = {
     if (operation["arguments"] == null) {
       operation["arguments"] = [];
     }
-    return Promise["try"](function() {
+    return fs.chmodAsync(operation.script, 755).then(function() {
       return child_process.spawn(operation.script, operation["arguments"]);
     });
   },

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -51,7 +51,7 @@ module.exports =
 		operation.script = path.join(image, operation.script)
 		operation.arguments ?= []
 
-		Promise.try ->
+		fs.chmodAsync(operation.script, 0o755).then ->
 			return child_process.spawn(operation.script, operation.arguments)
 
 	burn: (image, operation, options) ->

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -387,6 +387,26 @@ wary.it 'should be rejected if the script does not exist', {}, ->
 	promise = utils.waitStreamToClose(configuration)
 	m.chai.expect(promise).to.be.rejectedWith('ENOENT')
 
+wary.it 'should run a script that doesn not have execution privileges', {}, ->
+	configuration = operations.execute EDISON_ZIP, [
+		command: 'run-script'
+		script: 'exec.cmd'
+		arguments: [ 'hello', 'world' ]
+	]
+
+	stdout = ''
+	stderr = ''
+
+	configuration.on 'stdout', (data) ->
+		stdout += data
+
+	configuration.on 'stderr', (data) ->
+		stderr += data
+
+	utils.waitStreamToClose(configuration).then ->
+		m.chai.expect(stdout.replace(/\r/g, '')).to.equal('hello world\n')
+		m.chai.expect(stderr).to.equal('')
+
 wary.it 'should be rejected if the script finishes with an error', {}, ->
 	configuration = operations.execute EDISON_ZIP, [
 		command: 'run-script'

--- a/tests/images/edison/exec.cmd
+++ b/tests/images/edison/exec.cmd
@@ -1,0 +1,3 @@
+:; echo $*; exit 0
+@ECHO OFF
+ECHO %*


### PR DESCRIPTION
Sometimes a script might not have execution permissions, resulting in an
EPERM issue when trying to run. In order to be defensive about that edge
case, we attempt to set execution permissions for the script before
running it.