### PR TITLE
Chdir to script dirname on run-script command

### DIFF
--- a/build/commands.js
+++ b/build/commands.js
@@ -59,7 +59,8 @@ module.exports = {
     if (operation["arguments"] == null) {
       operation["arguments"] = [];
     }
-    return fs.chmodAsync(operation.script, 755).then(function() {
+    return fs.chmodAsync(operation.script, 0x1ed).then(function() {
+      process.chdir(image);
       return child_process.spawn(operation.script, operation["arguments"]);
     });
   },

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -52,6 +52,11 @@ module.exports =
 		operation.arguments ?= []
 
 		fs.chmodAsync(operation.script, 0o755).then ->
+
+			# Some scripts rely on other executable
+			# files within the same directory
+			process.chdir(image)
+
 			return child_process.spawn(operation.script, operation.arguments)
 
 	burn: (image, operation, options) ->

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -416,6 +416,25 @@ wary.it 'should be rejected if the script finishes with an error', {}, ->
 	promise = utils.waitStreamToClose(configuration)
 	m.chai.expect(promise).to.be.rejectedWith('Exitted with error code: 1')
 
+wary.it 'should change directory to the dirname of the script', {}, ->
+	configuration = operations.execute EDISON_ZIP, [
+		command: 'run-script'
+		script: 'cwd.cmd'
+	]
+
+	stdout = ''
+	stderr = ''
+
+	configuration.on 'stdout', (data) ->
+		stdout += data
+
+	configuration.on 'stderr', (data) ->
+		stderr += data
+
+	utils.waitStreamToClose(configuration).then ->
+		m.chai.expect(stdout.replace(/\r/g, '')).to.equal("#{EDISON_ZIP}#{path.sep}\n")
+		m.chai.expect(stderr).to.equal('')
+
 wary.it 'should be rejected if the burn operation lacks a drive option', {}, ->
 	configuration = operations.execute RASPBERRY_PI, [
 		command: 'burn'

--- a/tests/images/edison/cwd.cmd
+++ b/tests/images/edison/cwd.cmd
@@ -1,0 +1,3 @@
+:; echo $PWD/; exit 0
+@ECHO OFF
+ECHO %~dp0


### PR DESCRIPTION
Some scripts, such as `flashall` from Intel Edison rely on other
executables being in the same directory.