### PR TITLE
Inherit stdio to allow interactive scripts

### DIFF
--- a/build/commands.js
+++ b/build/commands.js
@@ -61,7 +61,8 @@ module.exports = {
     }
     return fs.chmodAsync(operation.script, 0x1ed).then(function() {
       return child_process.spawn(operation.script, operation["arguments"], {
-        cwd: image
+        cwd: image,
+        stdio: [process.stdin, 'pipe', 'pipe']
       });
     });
   },

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -58,6 +58,15 @@ module.exports =
 				# files within the same directory
 				cwd: image
 
+				# Inherit stdio so we can interact with script.
+				# We're not able to test this since stdin file
+				# descriptor is not opened for writing when not
+				# running the process in a tty.
+				# Notice we pass `process.stdin` directly instead
+				# of using 'inherit' since the latter one is
+				# not supported in v0.10.
+				stdio: [ process.stdin, 'pipe', 'pipe' ]
+
 	burn: (image, operation, options) ->
 
 		# Default image to the given path


### PR DESCRIPTION
This feature couldn't be tested in e2e.coffee since
`process.stdin.write()` makes not effect.

This is because the stdin file descriptor is not open for writing when
not running in a tty.