### PR TITLE
Set an os option by default

### DIFF
--- a/build/operations.js
+++ b/build/operations.js
@@ -108,6 +108,12 @@ action = require('./action');
 
 exports.execute = function(image, operations, options) {
   var emitter, missingOptions;
+  if (options == null) {
+    options = {};
+  }
+  if (options.os == null) {
+    options.os = utils.getOperatingSystem();
+  }
   missingOptions = utils.getMissingOptions(operations, options);
   if (!_.isEmpty(missingOptions)) {
     throw new Error("Missing options: " + (_.str.toSentence(missingOptions)));

--- a/build/utils.js
+++ b/build/utils.js
@@ -22,9 +22,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var Promise, _;
+var Promise, _, os;
 
 Promise = require('bluebird');
+
+os = require('os');
 
 _ = require('lodash');
 
@@ -150,4 +152,27 @@ exports.getMissingOptions = function(operations, options) {
   }
   usedOptions = _.flatten(_.map(_.pluck(operations, 'when'), _.keys));
   return _.uniq(_.difference(usedOptions, _.keys(options)));
+};
+
+
+/**
+ * @summary Get operating system
+ * @function
+ * @protected
+ *
+ * @returns {String} operating system
+ *
+ * @example
+ * os = utils.getOperatingSystem()
+ */
+
+exports.getOperatingSystem = function() {
+  var platform;
+  platform = os.platform();
+  switch (platform) {
+    case 'darwin':
+      return 'osx';
+    default:
+      return platform;
+  }
 };

--- a/lib/operations.coffee
+++ b/lib/operations.coffee
@@ -97,7 +97,9 @@ action = require('./action')
 # execution.on 'end', ->
 # 	console.log('Finished all operations')
 ###
-exports.execute = (image, operations, options) ->
+exports.execute = (image, operations, options = {}) ->
+	options.os ?= utils.getOperatingSystem()
+
 	missingOptions = utils.getMissingOptions(operations, options)
 
 	if not _.isEmpty(missingOptions)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ###
 
 Promise = require('bluebird')
+os = require('os')
 _ = require('lodash')
 
 ###*
@@ -126,3 +127,20 @@ exports.filterWhenMatches = (operations, options = {}) ->
 exports.getMissingOptions = (operations, options = {}) ->
 	usedOptions = _.flatten(_.map(_.pluck(operations, 'when'), _.keys))
 	return _.uniq(_.difference(usedOptions, _.keys(options)))
+
+###*
+# @summary Get operating system
+# @function
+# @protected
+#
+# @returns {String} operating system
+#
+# @example
+# os = utils.getOperatingSystem()
+###
+exports.getOperatingSystem = ->
+	platform = os.platform()
+
+	switch platform
+		when 'darwin' then 'osx'
+		else platform

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -470,6 +470,89 @@ wary.it 'should be able to burn an image',
 		.then (results) ->
 			m.chai.expect(results.random).to.deep.equal(results.raspberrypi)
 
+wary.it 'should set an os option automatically',
+	edison: EDISON
+, (images) ->
+	configuration = operations.execute images.edison, [
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'win32'
+			when:
+				os: 'win32'
+		,
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'osx'
+			when:
+				os: 'osx'
+		,
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'linux'
+			when:
+				os: 'linux'
+	]
+
+	utils.waitStreamToClose(configuration).then ->
+		imagefs.read
+			image: images.edison
+			path: '/config.json'
+		.then(extract)
+	.then (contents) ->
+		m.chai.expect(contents).to.equal(utils.getOperatingSystem())
+
+wary.it 'should allow the os option to be overrided',
+	edison: EDISON
+, (images) ->
+	configuration = operations.execute images.edison, [
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'win32'
+			when:
+				os: 'win32'
+		,
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'osx'
+			when:
+				os: 'osx'
+		,
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'linux'
+			when:
+				os: 'linux'
+		,
+			command: 'replace'
+			file:
+				path: '/config.json'
+			find: /^.*$/g
+			replace: 'resinos'
+			when:
+				os: 'resinos'
+	],
+		os: 'resinos'
+
+	utils.waitStreamToClose(configuration).then ->
+		imagefs.read
+			image: images.edison
+			path: '/config.json'
+		.then(extract)
+	.then (contents) ->
+		m.chai.expect(contents).to.equal('resinos')
+
 wary.run().catch (error) ->
 	console.error(error.message)
 	process.exit(1)

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,5 +1,6 @@
 m = require('mochainon')
 _ = require('lodash')
+os = require('os')
 Promise = require('bluebird')
 EventEmitter = require('events').EventEmitter
 utils = require('../lib/utils')
@@ -269,3 +270,41 @@ describe 'Utils:', ->
 			it 'should return the missing option once', ->
 				result = utils.getMissingOptions(@operations, null)
 				m.chai.expect(result).to.deep.equal([ 'os' ])
+
+	describe '.getOperatingSystem()', ->
+
+		describe 'given darwin', ->
+
+			beforeEach ->
+				@osPlatformStub = m.sinon.stub(os, 'platform')
+				@osPlatformStub.returns('darwin')
+
+			afterEach ->
+				@osPlatformStub.restore()
+
+			it 'should return osx', ->
+				m.chai.expect(utils.getOperatingSystem()).to.equal('osx')
+
+		describe 'given win32', ->
+
+			beforeEach ->
+				@osPlatformStub = m.sinon.stub(os, 'platform')
+				@osPlatformStub.returns('win32')
+
+			afterEach ->
+				@osPlatformStub.restore()
+
+			it 'should return win32', ->
+				m.chai.expect(utils.getOperatingSystem()).to.equal('win32')
+
+		describe 'given linux', ->
+
+			beforeEach ->
+				@osPlatformStub = m.sinon.stub(os, 'platform')
+				@osPlatformStub.returns('linux')
+
+			afterEach ->
+				@osPlatformStub.restore()
+
+			it 'should return linux', ->
+				m.chai.expect(utils.getOperatingSystem()).to.equal('linux')


### PR DESCRIPTION
We shouldn't rely on the client of the module to always remember to pass an
`os` option that adheres to our specification.

To make things easier, we pass by default, but still allow it to be
overrided for custom use cases, like testing.